### PR TITLE
Add Fuel Balance opening-entry seeding and ledger guardrails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`fuel_tracker` is a **Frappe v15 custom app** (Python 3.10+), not a standalone project. It lives inside a Frappe bench at `apps/fuel_tracker`; the bench root is two levels up (`fb-15-3/`). Almost every command runs from the **bench root**, not from this directory, and against a specific site. The app tracks bulk fuel supplied to tankers and fuel dispensed to resources (trucks/equipment), maintaining running balances through a ledger.
+
+## Commands
+
+Run from the **bench root** (`fb-15-3/`), substituting the actual site name for `<site>`:
+
+```bash
+# Run all app tests
+bench --site <site> run-tests --app fuel_tracker
+
+# Run tests for a single doctype (module path, not file path)
+bench --site <site> run-tests --module fuel_tracker.fuel_tracker.doctype.fuel_entry.test_fuel_entry
+
+# Apply code/schema changes after editing a doctype JSON or Python controller
+bench --site <site> migrate
+
+# Rebuild JS/CSS assets after editing client scripts
+bench build --app fuel_tracker
+
+# Tail logs / open a shell with the frappe context loaded
+bench --site <site> console
+```
+
+CI (`.github/workflows/ci.yml`) provisions a fresh bench + MariaDB, installs the app onto `test_site`, sets `allow_tests true`, then runs `run-tests --app fuel_tracker`. There is no separate lint step configured.
+
+## Architecture: the fuel ledger
+
+The domain is a **double-entry-style ledger**. Understanding the flow between four doctypes is the key to this codebase — they are wired through Frappe document lifecycle hooks (`on_submit` / `on_cancel`), not direct calls.
+
+- **`Fuel Supplied`** (submittable) — fuel arriving into a tanker. On submit → creates a `Fuel Entry` with `utilization_type="Supplied"` that *adds* to the balance.
+- **`Fuel Used`** (submittable) — fuel dispensed from a tanker to a resource. On submit → validates the odometer/hours reading, creates a `Fuel Entry` with `utilization_type="Dispensed"` that *subtracts* from the balance, and writes the new reading back to the `Resource`.
+- **`Fuel Entry`** — the immutable ledger line. Its own `on_submit` mutates the per-tanker `Fuel Balance`. Its `on_cancel` reverses the balance change **and cascades a cancel to the source `Fuel Supplied`/`Fuel Used` doc** (via `fuel_supplied_id` / `fuel_utilization_id`), and restores the resource's previous odometer/hours. Cancellation logic lives here, so `Fuel Entry` is the single place balance and resource state get unwound.
+- **`Fuel Balance`** — one running-balance row per `fuel_tanker` (autoname `field:fuel_tanker`, unique). Created lazily the first time a tanker is touched. This is current-state, not history; history is the set of `Fuel Entry` rows. On submit (`on_submit`), if the tanker has no *active* `Fuel Entry` yet (cancelled entries, `docstatus=2`, don't count), it seeds an opening entry (`utilization_type="Opening Balance"`) carrying `date`/`site`/`fuel_tanker` and the opening `balance` into `current_balance`, so the ledger starts from the entered balance. Once the tanker has a submitted `Fuel Entry`, the balance is locked: `on_cancel`/`on_trash` block cancel/delete, and the client script (`fuel_balance.js`) makes all fields read-only. Releasing it means cancelling the `Fuel Entry` first. **Do not** add a server-side guard that blocks *editing* a submitted balance — `FuelEntry.update_fuel_balance` saves this doc on every ledger change, so an edit-block would break the ledger.
+
+Consequence: never mutate `Fuel Balance` or `Resource` readings directly. Route changes through submitting/cancelling `Fuel Supplied` or `Fuel Used` so the ledger, balance, and resource state stay consistent.
+
+### Resource type is a pervasive branch
+
+A `Resource` is either a **`Truck`** (tracked by `odometer_km`) or **`Equipment`** (tracked by `hours_copy`). This distinction branches almost everywhere: validation (reading can't go backwards), which field gets fetched/written back, and consumption math in the reports. When adding logic that touches a resource, handle both arms.
+
+## REST API layer (`fuel_tracker/api/`)
+
+`api/login.py`, `api/fuel_used.py`, and `api/dashboard.py` hold `@frappe.whitelist()` functions consumed by an **external mobile/web client** over Frappe's v2 REST API (`/api/v2/method/fuel_tracker.api.<module>.<fn>`; canonical URLs are listed in comments at the bottom of `fuel_used.py`). These read the JSON body via `frappe.request.get_data()` rather than positional args. `login.verify_login` authenticates and returns/generates the user's `api_key`/`api_secret` for subsequent calls.
+
+**Gotcha:** the `doc_events` block in `hooks.py` maps placeholder doctypes `Doctype1`..`Doctype11` to these API functions. Those doctypes do not exist, so those hooks never fire — the block is effectively dead config. The API functions are reached only through the whitelisted REST endpoints above, not through document events. Don't treat that block as live wiring.
+
+## Reports (`fuel_tracker/report/`)
+
+Query reports (`fuel_ledger`, `average_fuel_consumption_ledger`, `fuel_balance`) are Python `execute(filters)` functions running raw SQL that `LEFT JOIN` `tabFuel Entry` with `tabFuel Used`. They filter on `docstatus = 1` (submitted only) and read the resource-type-specific diff columns (`diff_odometer` vs `diff_hours_copy`). `average_fuel_consumption_ledger` computes per-resource consumption vs a stored `average_consumption` baseline and emits an `alert_status` (Good / Warning / High Alert) — that alerting logic is the report's main purpose.
+
+## Conventions
+
+- **Doctype naming:** doctype *labels* have spaces (`Fuel Used`, `Fuel Entry`); their folders/modules are snake_case (`fuel_used`). SQL table names are `tab<Label>` (`` `tabFuel Entry` ``).
+- Each doctype dir holds the controller (`.py`), schema (`.json`), client script (`.js`), and test (`test_*.py`). Edit the JSON to change fields, then `migrate`.
+- The single Frappe module is **Fuel Tracker** (`modules.txt`). New doctypes/reports must declare `"module": "Fuel Tracker"`.
+- Client-side validation (e.g. `fuel_used.js`) is mirrored by server-side validation in the controller — keep both in sync; the server check is authoritative.

--- a/fuel_tracker/fuel_tracker/doctype/fuel_balance/fuel_balance.js
+++ b/fuel_tracker/fuel_tracker/doctype/fuel_balance/fuel_balance.js
@@ -1,8 +1,23 @@
 // Copyright (c) 2024, Carbonite Solutions Ltd and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Fuel Balance", {
-// 	refresh(frm) {
+frappe.ui.form.on("Fuel Balance", {
+	refresh(frm) {
+		// Once the tanker's ledger holds a submitted Fuel Entry, lock the
+		// balance down: every field becomes read-only and saving is disabled.
+		// Cancel/delete are blocked server-side (see fuel_balance.py).
+		if (!frm.doc.fuel_tanker || frm.doc.docstatus !== 1) {
+			return;
+		}
 
-// 	},
-// });
+		frappe.db.get_list("Fuel Entry", {
+			filters: { fuel_tanker: frm.doc.fuel_tanker, docstatus: 1 },
+			limit: 1,
+		}).then((entries) => {
+			if (entries && entries.length) {
+				frm.set_read_only();
+				frm.disable_save();
+			}
+		});
+	},
+});

--- a/fuel_tracker/fuel_tracker/doctype/fuel_balance/fuel_balance.py
+++ b/fuel_tracker/fuel_tracker/doctype/fuel_balance/fuel_balance.py
@@ -1,6 +1,60 @@
-# import frappe
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
 class FuelBalance(Document):
-	pass
+	def on_submit(self):
+		self.seed_opening_fuel_entry()
+
+	def on_cancel(self):
+		self.block_if_active_ledger("cancelled")
+
+	def on_trash(self):
+		self.block_if_active_ledger("deleted")
+
+	def block_if_active_ledger(self, action):
+		"""Protect a balance whose tanker already has a submitted Fuel Entry.
+
+		Once the ledger holds a submitted entry for this tanker, the balance is
+		the anchor of that ledger and must not be cancelled or deleted. The
+		Fuel Entry has to be cancelled first to release the balance.
+		"""
+		if not self.fuel_tanker:
+			return
+
+		if frappe.db.exists("Fuel Entry", {"fuel_tanker": self.fuel_tanker, "docstatus": 1}):
+			frappe.throw(
+				_("This Fuel Balance cannot be {0} because tanker {1} has a submitted Fuel Entry. Cancel the Fuel Entry first.")
+				.format(action, frappe.bold(self.fuel_tanker))
+			)
+
+	def seed_opening_fuel_entry(self):
+		"""Create the opening Fuel Entry for this tanker's ledger.
+
+		The very first time a Fuel Balance is submitted for a fuel tanker there
+		is no ledger history yet, so seed a Fuel Entry that carries the opening
+		balance forward. Subsequent balances are skipped because the tanker
+		already has at least one Fuel Entry.
+		"""
+		if not self.fuel_tanker:
+			return
+
+		# Only seed when this tanker has no active ledger history yet.
+		# Cancelled Fuel Entries (docstatus 2) are ignored, so a fresh balance
+		# can re-seed after the previous opening entry was cancelled.
+		if frappe.db.exists("Fuel Entry", {"fuel_tanker": self.fuel_tanker, "docstatus": ["!=", 2]}):
+			return
+
+		opening_entry = frappe.get_doc({
+			"doctype": "Fuel Entry",
+			"date": self.date,
+			"site": self.site,
+			"fuel_tanker": self.fuel_tanker,
+			"utilization_type": "Opening Balance",
+			"previous_balance": 0,
+			"current_balance": self.balance or 0,
+		})
+		opening_entry.flags.ignore_permissions = True
+		opening_entry.insert()
+		opening_entry.submit()

--- a/fuel_tracker/fuel_tracker/doctype/fuel_entry/fuel_entry.json
+++ b/fuel_tracker/fuel_tracker/doctype/fuel_entry/fuel_entry.json
@@ -175,6 +175,7 @@
  "owner": "Administrator",
  "permissions": [
   {
+   "cancel": 1,
    "create": 1,
    "delete": 1,
    "email": 1,

--- a/fuel_tracker/fuel_tracker/doctype/fuel_entry/fuel_entry.py
+++ b/fuel_tracker/fuel_tracker/doctype/fuel_entry/fuel_entry.py
@@ -43,6 +43,13 @@ class FuelEntry(Document):
         if existing_balance:
             # Update the existing Fuel Balance
             balance_entry = frappe.get_doc("Fuel Balance", existing_balance[0].name)
+
+            # A cancelled Fuel Balance can't be edited and no longer holds a live
+            # figure to adjust, so leave it untouched. This keeps a Fuel Entry
+            # cancellable even when its Fuel Balance was already cancelled.
+            if balance_entry.docstatus == 2:
+                return
+
             balance_entry.date = self.date
         else:
             # Or create a new Fuel Balance if none exists

--- a/fuel_tracker/fuel_tracker/doctype/fuel_used/fuel_used.json
+++ b/fuel_tracker/fuel_tracker/doctype/fuel_used/fuel_used.json
@@ -51,7 +51,7 @@
   {
    "fieldname": "resource",
    "fieldtype": "Link",
-   "label": "Resource",
+   "label": "Vehicle Registration/Machine Code",
    "options": "Resource",
    "reqd": 1
   },
@@ -94,10 +94,10 @@
    "fieldtype": "Section Break"
   },
   {
-   "fetch_from": "resource.reg_no",
+   "fetch_from": "resource.chassis_number",
    "fieldname": "reg_no",
    "fieldtype": "Data",
-   "label": "Reg. No",
+   "label": "Chassis Number",
    "read_only": 1
   },
   {
@@ -202,11 +202,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-02-11 10:49:53.812932",
+ "modified": "2026-07-02 13:05:14.402429",
  "modified_by": "Administrator",
  "module": "Fuel Tracker",
  "name": "Fuel Used",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/fuel_tracker/fuel_tracker/doctype/resource/resource.json
+++ b/fuel_tracker/fuel_tracker/doctype/resource/resource.json
@@ -98,7 +98,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-06 14:24:47.806777",
+ "modified": "2026-07-02 13:10:17.626916",
  "modified_by": "Administrator",
  "module": "Fuel Tracker",
  "name": "Resource",
@@ -119,7 +119,9 @@
   }
  ],
  "row_format": "Dynamic",
+ "show_title_field_in_link": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "title_field": "reg_no"
 }


### PR DESCRIPTION
Seed an opening Fuel Entry when a Fuel Balance is submitted for a tanker with no active ledger entry.

Lock a Fuel Balance once its tanker has a submitted Fuel Entry: block cancel/delete server-side and make all fields read-only in the form.

Grant cancel permission on Fuel Entry and skip cancelled balances in update_fuel_balance so entries remain cancellable.

Relabel Fuel Used resource/chassis fields and set the Resource title field.

Add CLAUDE.md project guide.