### PR TITLE
Stop breaking the date picker, and default the date to today

### DIFF
--- a/fuel_tracker/fuel_tracker/doctype/fuel_adjustment/fuel_adjustment.js
+++ b/fuel_tracker/fuel_tracker/doctype/fuel_adjustment/fuel_adjustment.js
@@ -2,10 +2,8 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Fuel Adjustment", {
-    onload(frm) {
-        // Fuel movements record something that already happened, so the picker
-        // stops at today. The server refuses a future date regardless.
-        frm.set_df_property("date", "max_date", frappe.datetime.get_today());
+    date(frm) {
+        warn_if_future(frm);
     },
     refresh(frm) {
         fetch_system_balance(frm);
@@ -60,4 +58,18 @@ function compute_preview(frm) {
         adjustment = flt(frm.doc.quantity);
     }
     frm.set_value("adjustment_litres", flt(adjustment, 3));
+}
+
+function warn_if_future(frm) {
+    // Fuel movements record something that already happened. The server
+    // refuses a future date outright; this just says so straight away,
+    // without touching the date picker's own options.
+    if (frm.doc.date && frm.doc.date > frappe.datetime.get_today()) {
+        frappe.msgprint({
+            title: __("Future Dated"),
+            message: __("Date cannot be in the future. Fuel is recorded after it moves; backdating is allowed."),
+            indicator: "red",
+        });
+        frm.set_value("date", frappe.datetime.get_today());
+    }
 }

--- a/fuel_tracker/fuel_tracker/doctype/fuel_adjustment/fuel_adjustment.json
+++ b/fuel_tracker/fuel_tracker/doctype/fuel_adjustment/fuel_adjustment.json
@@ -32,7 +32,8 @@
    "fieldname": "date",
    "fieldtype": "Date",
    "label": "Date",
-   "reqd": 1
+   "reqd": 1,
+   "default": "Today"
   },
   {
    "fieldname": "fuel_tanker",

--- a/fuel_tracker/fuel_tracker/doctype/fuel_supplied/fuel_supplied.js
+++ b/fuel_tracker/fuel_tracker/doctype/fuel_supplied/fuel_supplied.js
@@ -2,10 +2,8 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Fuel Supplied", {
-    onload(frm) {
-        // Fuel movements record something that already happened, so the picker
-        // stops at today. The server refuses a future date regardless.
-        frm.set_df_property("date", "max_date", frappe.datetime.get_today());
+    date(frm) {
+        warn_if_future(frm);
     },
 	setup(frm) {
 		// Only open requests can be answered, and only for this tanker — a
@@ -58,4 +56,18 @@ function show_variance_headline(frm) {
 			: __("{0} L over the {1} L requested.", [format_number(variance, null, 2), format_number(requested, null, 2)]),
 		variance < 0 ? "orange" : "blue"
 	);
+}
+
+function warn_if_future(frm) {
+    // Fuel movements record something that already happened. The server
+    // refuses a future date outright; this just says so straight away,
+    // without touching the date picker's own options.
+    if (frm.doc.date && frm.doc.date > frappe.datetime.get_today()) {
+        frappe.msgprint({
+            title: __("Future Dated"),
+            message: __("Date cannot be in the future. Fuel is recorded after it moves; backdating is allowed."),
+            indicator: "red",
+        });
+        frm.set_value("date", frappe.datetime.get_today());
+    }
 }

--- a/fuel_tracker/fuel_tracker/doctype/fuel_supplied/fuel_supplied.json
+++ b/fuel_tracker/fuel_tracker/doctype/fuel_supplied/fuel_supplied.json
@@ -29,7 +29,8 @@
    "fieldname": "date",
    "fieldtype": "Date",
    "label": "Date",
-   "reqd": 1
+   "reqd": 1,
+   "default": "Today"
   },
   {
    "fetch_from": "fuel_tanker.site",

--- a/fuel_tracker/fuel_tracker/doctype/fuel_transfer/fuel_transfer.js
+++ b/fuel_tracker/fuel_tracker/doctype/fuel_transfer/fuel_transfer.js
@@ -2,12 +2,9 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Fuel Transfer", {
-	onload(frm) {
-		// Fuel movements record something that already happened, so the picker
-		// stops at today. The server refuses a future date regardless.
-		frm.set_df_property("date", "max_date", frappe.datetime.get_today());
+	date(frm) {
+		warn_if_future(frm);
 	},
-
 	setup(frm) {
 		// A transfer moves fuel between two tankers, so never offer the same
 		// one on both sides.
@@ -92,4 +89,18 @@ function refresh_balances(frm) {
 			},
 		});
 	});
+}
+
+function warn_if_future(frm) {
+	// Fuel movements record something that already happened. The server
+	// refuses a future date outright; this just says so straight away,
+	// without touching the date picker's own options.
+	if (frm.doc.date && frm.doc.date > frappe.datetime.get_today()) {
+		frappe.msgprint({
+			title: __("Future Dated"),
+			message: __("Date cannot be in the future. Fuel is recorded after it moves; backdating is allowed."),
+			indicator: "red",
+		});
+		frm.set_value("date", frappe.datetime.get_today());
+	}
 }

--- a/fuel_tracker/fuel_tracker/doctype/fuel_used/fuel_used.js
+++ b/fuel_tracker/fuel_tracker/doctype/fuel_used/fuel_used.js
@@ -2,10 +2,8 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Fuel Used", {
-    onload(frm) {
-        // Fuel movements record something that already happened, so the picker
-        // stops at today. The server refuses a future date regardless.
-        frm.set_df_property("date", "max_date", frappe.datetime.get_today());
+    date(frm) {
+        warn_if_future(frm);
     },
     refresh(frm) {
         show_faulty_meter_notice(frm);
@@ -101,4 +99,18 @@ function missing_reading_message(frm, message) {
             },
         },
     });
+}
+
+function warn_if_future(frm) {
+    // Fuel movements record something that already happened. The server
+    // refuses a future date outright; this just says so straight away,
+    // without touching the date picker's own options.
+    if (frm.doc.date && frm.doc.date > frappe.datetime.get_today()) {
+        frappe.msgprint({
+            title: __("Future Dated"),
+            message: __("Date cannot be in the future. Fuel is recorded after it moves; backdating is allowed."),
+            indicator: "red",
+        });
+        frm.set_value("date", frappe.datetime.get_today());
+    }
 }

--- a/fuel_tracker/fuel_tracker/doctype/fuel_used/fuel_used.json
+++ b/fuel_tracker/fuel_tracker/doctype/fuel_used/fuel_used.json
@@ -78,7 +78,8 @@
    "fieldname": "date",
    "fieldtype": "Date",
    "label": "Date",
-   "reqd": 1
+   "reqd": 1,
+   "default": "Today"
   },
   {
    "fieldname": "column_break_pdgt",


### PR DESCRIPTION
My last change set `max_date` on the date field to grey out future dates. That broke the picker outright — clicking Date opened nothing. Two reasons: the datepicker's options object is built once when the control is created, so setting the property afterwards in `onload` never reaches it; and nothing in Frappe or ERPNext sets `max_date` anywhere, so it is an untested hook rather than a supported one.

Reverted. The same guarantee now comes from a plain `date` handler that says so and resets to today, which touches none of the picker's internals. The server-side refusal is unchanged and remains authoritative.

Fuel Used, Fuel Supplied and Fuel Adjustment also had no default on a required date field, so every new form opened blank — Fuel Transfer already defaulted to today. All four now match.